### PR TITLE
Automatically set full task version in Azure Pipeline

### DIFF
--- a/.azure/publish-extension.yml
+++ b/.azure/publish-extension.yml
@@ -50,7 +50,7 @@ stages:
             extensionName: '$(ExtensionName)'
             extensionVersion: ${{ variables['extensionVersion'] }}
             updateTasksVersion: true
-            updateTasksVersionType: 'patch'
+            updateTasksVersionType: 'major'
             extensionVisibility: '$(ExtensionVisibility)'
             extensionPricing: 'free'
             updateTasksId: true


### PR DESCRIPTION
This will bump the major version of the task in the published extension so it's officially v1 now.