### PR TITLE
Updated to the correct eslint formatter fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "cpy-cli": "^4.2.0",
                 "eslint": "^8.34.0",
                 "eslint-config-standard-with-typescript": "^34.0.0",
-                "eslint-formatter-friendly": "github:Xerillio/eslint-friendly-formatter#5b12360ea34f934941a169f48dec358befc4dcb6",
+                "eslint-formatter-friendly": "github:xerillio/eslint-formatter-friendly#af80c289aa56feb587b9cd3bfc370ce42aba3eca",
                 "eslint-plugin-import": "^2.27.5",
                 "eslint-plugin-n": "^15.6.1",
                 "eslint-plugin-promise": "^6.1.1",
@@ -876,12 +876,12 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+            "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
             "dev": true,
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/ansi-styles": {
@@ -1313,72 +1313,6 @@
             },
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/chalk": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/babel-code-frame/node_modules/supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.8.0"
             }
         },
         "node_modules/babel-runtime": {
@@ -1961,12 +1895,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/coalescy": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/coalescy/-/coalescy-1.0.0.tgz",
-            "integrity": "sha512-OmRR46eVfyaXZYI7Ai5/vnLHjWhhh99sugx+UTsmVhwaYzARb+Tcdit59/HkVxF8KdqJG5NN8ClUhzQXS3Hh+w==",
-            "dev": true
         },
         "node_modules/color-convert": {
             "version": "1.9.3",
@@ -3009,22 +2937,29 @@
             }
         },
         "node_modules/eslint-formatter-friendly": {
-            "version": "5.0.0",
-            "resolved": "git+ssh://git@github.com/Xerillio/eslint-friendly-formatter.git#5b12360ea34f934941a169f48dec358befc4dcb6",
-            "integrity": "sha512-zG3ZEvw4lWJ4dte3O2CxWgCtgG8n+ZbxzaEDgiV+6a9ivrbbr1kFBe+LVsH/xgJVykbRVxxkUSbsz5zCAyWh/g==",
+            "version": "7.0.0",
+            "resolved": "git+ssh://git@github.com/xerillio/eslint-formatter-friendly.git#af80c289aa56feb587b9cd3bfc370ce42aba3eca",
+            "integrity": "sha512-N2xVva6Vr89F78vTiNRWRu7NqynoKpclIukOULv3Kk/hRchCyxJ471LN3yW3GzAB71SVIb2krqHlijr+iNPepw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "babel-code-frame": "6.26.0",
-                "chalk": "^2.0.1",
-                "coalescy": "1.0.0",
-                "extend": "^3.0.2",
-                "minimist": "^1.2.0",
-                "strip-ansi": "^4.0.0",
-                "text-table": "^0.2.0"
+                "@babel/code-frame": "7.0.0",
+                "chalk": "2.4.2",
+                "extend": "3.0.2",
+                "strip-ansi": "5.2.0",
+                "text-table": "0.2.0"
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/eslint-formatter-friendly/node_modules/@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/highlight": "^7.0.0"
             }
         },
         "node_modules/eslint-import-resolver-node": {
@@ -4221,27 +4156,6 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/has-ansi/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -4922,12 +4836,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/js-sdsl"
             }
-        },
-        "node_modules/js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-            "dev": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
@@ -7300,15 +7208,15 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "dev": true,
             "dependencies": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "^4.1.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=6"
             }
         },
         "node_modules/strip-bom": {
@@ -9076,9 +8984,9 @@
             }
         },
         "ansi-regex": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+            "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
             "dev": true
         },
         "ansi-styles": {
@@ -9421,59 +9329,6 @@
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
-                }
-            }
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-                    "dev": true
                 }
             }
         },
@@ -9934,12 +9789,6 @@
                     }
                 }
             }
-        },
-        "coalescy": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/coalescy/-/coalescy-1.0.0.tgz",
-            "integrity": "sha512-OmRR46eVfyaXZYI7Ai5/vnLHjWhhh99sugx+UTsmVhwaYzARb+Tcdit59/HkVxF8KdqJG5NN8ClUhzQXS3Hh+w==",
-            "dev": true
         },
         "color-convert": {
             "version": "1.9.3",
@@ -10891,18 +10740,27 @@
             }
         },
         "eslint-formatter-friendly": {
-            "version": "git+ssh://git@github.com/Xerillio/eslint-friendly-formatter.git#5b12360ea34f934941a169f48dec358befc4dcb6",
-            "integrity": "sha512-zG3ZEvw4lWJ4dte3O2CxWgCtgG8n+ZbxzaEDgiV+6a9ivrbbr1kFBe+LVsH/xgJVykbRVxxkUSbsz5zCAyWh/g==",
+            "version": "git+ssh://git@github.com/xerillio/eslint-formatter-friendly.git#af80c289aa56feb587b9cd3bfc370ce42aba3eca",
+            "integrity": "sha512-N2xVva6Vr89F78vTiNRWRu7NqynoKpclIukOULv3Kk/hRchCyxJ471LN3yW3GzAB71SVIb2krqHlijr+iNPepw==",
             "dev": true,
-            "from": "eslint-formatter-friendly@github:Xerillio/eslint-friendly-formatter#5b12360ea34f934941a169f48dec358befc4dcb6",
+            "from": "eslint-formatter-friendly@github:xerillio/eslint-formatter-friendly#af80c289aa56feb587b9cd3bfc370ce42aba3eca",
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "chalk": "^2.0.1",
-                "coalescy": "1.0.0",
-                "extend": "^3.0.2",
-                "minimist": "^1.2.0",
-                "strip-ansi": "^4.0.0",
-                "text-table": "^0.2.0"
+                "@babel/code-frame": "7.0.0",
+                "chalk": "2.4.2",
+                "extend": "3.0.2",
+                "strip-ansi": "5.2.0",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+                    "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.0.0"
+                    }
+                }
             }
         },
         "eslint-import-resolver-node": {
@@ -11647,23 +11505,6 @@
                 "function-bind": "^1.1.1"
             }
         },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-                    "dev": true
-                }
-            }
-        },
         "has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -12145,12 +11986,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
             "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-            "dev": true
-        },
-        "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
             "dev": true
         },
         "js-yaml": {
@@ -13969,12 +13804,12 @@
             }
         },
         "strip-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-            "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "^4.1.0"
             }
         },
         "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "cpy-cli": "^4.2.0",
         "eslint": "^8.34.0",
         "eslint-config-standard-with-typescript": "^34.0.0",
-        "eslint-formatter-friendly": "github:Xerillio/eslint-friendly-formatter#5b12360ea34f934941a169f48dec358befc4dcb6",
+        "eslint-formatter-friendly": "github:xerillio/eslint-formatter-friendly#af80c289aa56feb587b9cd3bfc370ce42aba3eca",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^15.6.1",
         "eslint-plugin-promise": "^6.1.1",


### PR DESCRIPTION
`github:Xerillio/eslint-friendly-formatter` was a fork of a deprecated repository. `github:xerillio/eslint-formatter-friendly` is the newest fork containing the latest features too.